### PR TITLE
Added payment splitter. changed migrations. added some tests

### DIFF
--- a/contracts/Payments.sol
+++ b/contracts/Payments.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.8.13;
+
+import "@openzeppelin/contracts/finance/PaymentSplitter.sol";
+
+contract Payments is PaymentSplitter {
+    address owner;
+    address publisher;
+    modifier OwnerOrPublisher() {
+        require(_msgSender() == owner || _msgSender() == publisher);
+        _;
+    }
+    constructor(address[] memory _payees, uint256[] memory _shares) PaymentSplitter(_payees, _shares) payable {
+        owner = _payees[0];
+        publisher = _payees[1];
+    }
+}

--- a/contracts/Subscribium.sol
+++ b/contracts/Subscribium.sol
@@ -3,12 +3,14 @@ pragma solidity ^0.8.13;
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/finance/PaymentSplitter.sol";
 
-contract Subscribium is Ownable {
+contract Subscribium is Ownable{
     using SafeMath for uint256;
 
     address public publisher;
     address public stablecoin;
+    address payable payments;
 
     mapping(address => SubscriptionTerms) public subscribers;
     mapping(address => uint256) nextValidTime;
@@ -18,9 +20,10 @@ contract Subscribium is Ownable {
         uint256 value;
     }
 
-    constructor(address _publisher, address _stablecoin) {
+    constructor(address _publisher, address _stablecoin, address payable _payments) {
         publisher = _publisher;
         stablecoin = _stablecoin;
+        payments = _payments;
     }
 
     function Subscribe(uint256 _interval, uint256 _value) public {
@@ -44,7 +47,7 @@ contract Subscribium is Ownable {
         
         bool result = ERC20(stablecoin).transferFrom(
             _subscriber,
-            address(this),
+            payments,
             subscribers[_subscriber].value
         );
 
@@ -55,6 +58,4 @@ contract Subscribium is Ownable {
 
         return result;
     }
-
-    
 }

--- a/migrations/2_MyToken.js
+++ b/migrations/2_MyToken.js
@@ -1,8 +1,13 @@
 const MyToken = artifacts.require("MyToken");
 const Subscribium = artifacts.require("Subscribium");
+const Payments = artifacts.require("Payments");
 
 module.exports = function (deployer) {
-  deployer.deploy(MyToken, 100).then(function() {
-    return deployer.deploy(Subscribium, "0x6b67d934c4cef8f4bce9b81d05cb2a9bbcba3697", MyToken.address)
+  let publisher = "0x6b67d934c4cef8f4bce9b81d05cb2a9bbcba3697"
+  let owner = "0xc094b40284653f178e89e003d00b85ead8fcc086"
+  deployer.deploy(MyToken, 100000).then(function() {
+    return deployer.deploy(Payments, [owner, publisher], [10, 90]).then(function() {
+      return deployer.deploy(Subscribium, publisher, MyToken.address, Payments.address)
+    })
   });
 };

--- a/test/Subscribium.js
+++ b/test/Subscribium.js
@@ -1,5 +1,6 @@
 const subs = artifacts.require("Subscribium");
 const token = artifacts.require("MyToken");
+const payments = artifacts.require("payments");
 
 contract('Subscribium', (accounts) => {
 
@@ -11,6 +12,7 @@ contract('Subscribium', (accounts) => {
         subsInstance = await subs.deployed();
         tokenInstance = await token.deployed();
         publisher = await subsInstance.publisher();
+        paymentsInstance = await payments.deployed();
     });
 
     it("publisher should be acccounts[9]", async () => {
@@ -38,12 +40,37 @@ contract('Subscribium', (accounts) => {
         const subscribers = await subsInstance.subscribers;
         const subscription = await subscribers(subscriber);
         
-        const interval = subscription.interval.words[0];
+        const value = subscription.value.words[0];
 
-        let result = await subsInstance.ExecuteSubscription(subscriber);
-        assert.equal(result, true, "subscription executed 1");
+        let balanceBefore = await tokenInstance.balanceOf(subscriber);
+        await subsInstance.ExecuteSubscription(subscriber);
+        let balanceAfter = await tokenInstance.balanceOf(subscriber);
 
-        result = await subsInstance.ExecuteSubscription(subscriber);
-        assert.equal(result, false, "subscription executed 2");
+        console.log("balance before: ", balanceBefore.words[0]); 
+        assert.equal(balanceBefore.words[0] - value, balanceAfter.words[0], "subscription executed 1");
+
+        balanceBefore = balanceAfter;
+        
+        try{
+            await subsInstance.ExecuteSubscription(subscriber);
+        } catch(e) {
+            console.log("*****************************************")
+        }
+
+        balanceAfter = await tokenInstance.balanceOf(subscriber);
+
+        assert.equal(balanceBefore.words[0], balanceAfter.words[0], "subscription did not executed 2");
+    });
+
+    it("should withdraw funds", async () => {
+        let balanceBefore = await tokenInstance.balanceOf(publisher);
+
+        await paymentsInstance.release(tokenInstance.address ,publisher);
+        let balanceAfter = await tokenInstance.balanceOf(publisher);
+
+        console.log("after: ", balanceAfter.words[0]);
+
+        assert.notEqual(balanceBefore.words[0], balanceAfter.words[0], "Falied to withdraw");
+        assert.equal(balanceAfter.words[0], 199, "Falied to withdraw");
     });
 });


### PR DESCRIPTION
### TL;DR

Added a payment splitting mechanism to the subscription system using OpenZeppelin's PaymentSplitter.

### What changed?

- Created a new `Payments.sol` contract that extends OpenZeppelin's PaymentSplitter
- Modified `Subscribium.sol` to redirect subscription payments to the Payments contract instead of storing them directly
- Updated the constructor in `Subscribium.sol` to accept a payments address parameter
- Added functionality to split payments between owner and publisher with configurable shares (10/90 by default)
- Added an `OwnerOrPublisher` modifier to restrict certain operations

### How to test?

1. Deploy the contracts using the migration script
2. Create a subscription using the `Subscribe` function
3. Execute the subscription with `ExecuteSubscription`
4. Verify that funds are properly transferred to the Payments contract
5. Call `release` on the Payments contract to withdraw funds to the publisher
6. Verify that the publisher receives the correct amount (90% of payments)

### Why make this change?

This change implements a more robust payment handling system that automatically splits subscription revenue between the platform owner and content publishers. By leveraging OpenZeppelin's PaymentSplitter, the system now provides transparent, secure payment distribution without requiring manual transfers or additional accounting logic.